### PR TITLE
Fix notice due to a possibly defined statement

### DIFF
--- a/wp_benchmark.php
+++ b/wp_benchmark.php
@@ -124,7 +124,9 @@ class wp_benchmark
 
 		if (in_array('queries', $this->options))
 		{
-			define('SAVEQUERIES', true);
+			if( ! defined( 'SAVEQUERIES' ) ) {
+				define('SAVEQUERIES', true);
+			}
 		}
 	}
 


### PR DESCRIPTION
A notice would arise if the constant has already been defined in wp-config.php or somewhere else.
